### PR TITLE
Updated WiFi guide to inform users to use `MSCHAPv2`

### DIFF
--- a/content/wifi.md
+++ b/content/wifi.md
@@ -17,7 +17,7 @@ When attempting to connect to the network, you will be prompted for the followin
 | Field | Input |
 | ----- | ----- |
 | EAP Method | Protected EAP (PEAP) |
-| Phase 2 Authentication | MSCHAP |
+| Phase 2 Authentication | MSCHAPv2 |
 | CA Certificate | Select from file -> `/etc/ssl/certs/ca-certificates.crt` [^1] |
 | Domain | uic.edu |
 | Identity | **Your UIC NetID** [^2]|


### PR DESCRIPTION
UIC WiFI guide currently tells users that the "Phase 2 Authentication" needs be `MSCHAP`. This has caused confusion among members who look for `MSCHAP` (presumably v1 to them) erroneously. 